### PR TITLE
Fixes

### DIFF
--- a/domena/symulacja.py
+++ b/domena/symulacja.py
@@ -1,7 +1,9 @@
 from scipy import signal
 
-from domena.encje.kolejka import Kolejka
-from domena.encje.obiekt_silnika import ObiektSilnika
+from encje.kolejka import Kolejka
+from encje.obiekt_silnika import ObiektSilnika
+
+wejscie = None
 
 
 class Symulacja:
@@ -14,35 +16,49 @@ class Symulacja:
         self.__czas_probkowania = 0.002
         self.__silnik = ObiektSilnika().transmitancja
         # [czas, wejście, wyjście]
-        self.__dane = {"czas": Kolejka(), "wejscie": Kolejka(), "wyjscie": Kolejka()}
+        self.dane = {"czas": Kolejka(), "wejscie": Kolejka(), "wyjscie": Kolejka()}
 
-    def aktualizacja_symulacji(self, wej: float):
+    def aktualizacja_symulacji(self):
         """
         Aktualizuje symulacje
         """
-        self.__dane["czas"].dodanie_do_kolejki(self.__dane['czas'].ostatnia_wartosc() + self.__czas_probkowania)
-        self.__dane['wejscie'].dodanie_do_kolejki(wej)
-        _, y, _ = signal.lsim(self.__silnik, U=self.__dane['wejscie'].aktualna_kolejka(),
-                              T=self.__dane['czas'].aktualna_kolejka())
-        self.__dane['wyjscie'].dodanie_do_kolejki(y[-1])
+        if wejscie is None:
+            return
+        self.dane["czas"].dodanie_do_kolejki(self.dane['czas'].ostatnia_wartosc() + self.__czas_probkowania)
+        self.dane['wejscie'].dodanie_do_kolejki(wejscie)
+        _, y, _ = signal.lsim(self.__silnik, U=self.dane['wejscie'].aktualna_kolejka(),
+                              T=self.dane['czas'].aktualna_kolejka())
+        self.dane['wyjscie'].dodanie_do_kolejki(y[-1])
 
     def aktualne_wartosci(self):
         """
         Zwraca aktualne wartosci
         """
-        return self.__dane
+        return self.dane
 
-
-if __name__ == "__main__":
+def thread_job():
+    global wejscie
+    wejscie = 1
     sym = Symulacja()
-    from matplotlib import pyplot as plt
-
-    for i in range(100):
-        wejscie = input("Podaj wejście: ")
-        sym.aktualizacja_symulacji(float(wejscie))
-        plt.plot(sym.__dane[0].aktualna_kolejka(), sym.__dane[2].aktualna_kolejka())
+    while True:
+        sym.aktualizacja_symulacji()
+        plt.plot(sym.dane["czas"].aktualna_kolejka(), sym.dane["wyjscie"].aktualna_kolejka())
         plt.xlabel("Czas")
         plt.ylabel("Wyjście")
         plt.title("Odpowiedź obiektu w czasie rzeczywistym")
         plt.show(block=False)
         plt.pause(0.1)
+
+if __name__ == "__main__":
+    sym = Symulacja()
+    from matplotlib import pyplot as plt
+    import threading
+    t = threading.Thread(target=thread_job)
+    t.start()
+    try:
+        while True:
+            wejscie = float(input("Podaj wejście: "))
+    except KeyboardInterrupt:
+        plt.close()
+        exit(0)
+


### PR DESCRIPTION
Nagłówki zmieniłem bo mi nie działało (python odpalany z terminala bez żadnych dev env). Mój pomysł na blokowanie pętli przy przerwaniu programu to dodatkowa zmienna globalna true/false np `zatrzymanie`, ustawianie jej przy wyłapaniu KeyboardInterrupt (to już masz) i opuszczenie wątka. Python chyba nie pozwala zabijać wątków potomnych z poziomu macierzystego więc to chyba jedne rozwiązanie. __dane też mi nie działało, błąd przy 
`plt.plot(sym.__dane["czas"].aktualna_kolejka(), sym.__dane["wyjscie"].aktualna_kolejka())`
Zmieniłem na nieprywatną konwencję nazwy zmiennej, to w sumie chyba też dobra praktyka.